### PR TITLE
Fix issue where a string status code was passed to Response::withStatus()

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -168,7 +168,7 @@ class Client
         }
 
         if (array_key_exists('Status', $headers)) {
-            $response = $response->withStatus($headers['Status']);
+            $response = $response->withStatus((int)$headers['Status']);
             unset($headers['Status']);
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -168,7 +168,7 @@ class Client
         }
 
         if (array_key_exists('Status', $headers)) {
-            $response = $response->withStatus((int)$headers['Status']);
+            $response = $response->withStatus((int) $headers['Status']);
             unset($headers['Status']);
         }
 

--- a/tests/Spiral/ClientTest.php
+++ b/tests/Spiral/ClientTest.php
@@ -104,7 +104,8 @@ RESP;
         $client = new Client($transport);
         $response = $client->request($request, $response);
 
-        $this->assertEquals(200, $response->getStatusCode());
+        // The status code should be passed as an int, not a string according to ResponseInterface::withStatus()
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertEquals('nginx', $response->getHeaderLine('Server'));
         $this->assertFalse($response->hasHeader('Location'));
         $this->assertEquals(1, preg_match('/^<!doctype html>/i', $response->getBody()));


### PR DESCRIPTION
I had an issue with using this library with [Slim HTTP](https://github.com/slimphp/Slim-Http) where slim was throwing an `InvalidArgumentException` due to an invalid status code.
The issue was in `Client.php` on line 171 where there was a call:
`$response->withStatus($headers['Status']);`.

This was passing a string status `'200'` into `withStatus()`.

PSR-7 says that this should be an int:
`@param int $code The 3-digit integer result code to set.`

This pull request adjusts the test so that it fails if a string (or anything that is not an int) is passed, and also casts the status code to an int before passing it to `withStatus()`.