### PR TITLE
Fix tests broken by linuxfoundation.org switching to https

### DIFF
--- a/tests/Spiral/Transport/CurlTest.php
+++ b/tests/Spiral/Transport/CurlTest.php
@@ -89,7 +89,7 @@ class CurlTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($transport->responseInfo());
 
-        $transport->request(Transport::METHOD_GET, 'http://www.linuxfoundation.org', ['Accept-Charset' => 'utf-8']);
+        $transport->request(Transport::METHOD_GET, 'http://www.php.net', ['Accept-Charset' => 'utf-8']);
 
         $this->assertInternalType('array', $transport->responseInfo());
         $this->assertEquals(200, $transport->responseInfo(CURLINFO_HTTP_CODE));
@@ -104,10 +104,10 @@ class CurlTest extends \PHPUnit_Framework_TestCase
     {
         $transport = Curl::createFromDefaults();
 
-        $transport->request(Transport::METHOD_GET, 'http://www.linuxfoundation.org', [], ['var' => 'value']);
+        $transport->request(Transport::METHOD_GET, 'http://www.php.net', [], ['var' => 'value']);
         $this->assertEquals(200, $transport->responseInfo(CURLINFO_HTTP_CODE));
 
-        $transport->request(Transport::METHOD_POST, 'http://www.linuxfoundation.org', [], ['var' => 'value']);
+        $transport->request(Transport::METHOD_POST, 'http://www.php.net', [], ['var' => 'value']);
         $this->assertEquals(200, $transport->responseInfo(CURLINFO_HTTP_CODE));
 
         $transport->close();
@@ -127,16 +127,17 @@ class CurlTest extends \PHPUnit_Framework_TestCase
      * @param string $method
      * @param string $shorthand
      *
+     * @param int $expectedCode
      * @dataProvider methodProvider
      */
     public function testRequestMethods($method, $shorthand, $expectedCode)
     {
         $transport = Curl::createFromDefaults();
 
-        $transport->request($method, 'http://www.linuxfoundation.org');
+        $transport->request($method, 'http://www.php.net');
         $this->assertEquals($expectedCode, $transport->responseInfo(CURLINFO_HTTP_CODE));
 
-        call_user_func([$transport, $shorthand], 'http://www.linuxfoundation.org');
+        call_user_func([$transport, $shorthand], 'http://www.php.net');
         $this->assertEquals($expectedCode, $transport->responseInfo(CURLINFO_HTTP_CODE));
 
         $transport->close();
@@ -153,7 +154,7 @@ class CurlTest extends \PHPUnit_Framework_TestCase
             [Transport::METHOD_OPTIONS, 'options', 200],
             [Transport::METHOD_HEAD, 'head', 200],
             [Transport::METHOD_GET, 'get', 200],
-            [Transport::METHOD_POST, 'post', 400],
+            [Transport::METHOD_POST, 'post', 200],
             [Transport::METHOD_PUT, 'put', 200],
             [Transport::METHOD_DELETE, 'delete', 200],
             [Transport::METHOD_PATCH, 'patch', 200],

--- a/tests/Spiral/Transport/CurlTest.php
+++ b/tests/Spiral/Transport/CurlTest.php
@@ -126,8 +126,8 @@ class CurlTest extends \PHPUnit_Framework_TestCase
      *
      * @param string $method
      * @param string $shorthand
+     * @param int    $expectedCode
      *
-     * @param int $expectedCode
      * @dataProvider methodProvider
      */
     public function testRequestMethods($method, $shorthand, $expectedCode)


### PR DESCRIPTION
It looks like since the tests were written, linuxfoundation.org added https and forced http users to the https site. This breaks the tests.

I've switched the tests to use php.net instead, but these are brittle and could easily break again