### PR TITLE
Psr7httpbody

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -121,7 +121,6 @@ class Client
         }
 
         $transferInfo = $transport->responseInfo();
-        $transport->close();
 
         $responseHeaders = '';
         $responseContent = $transferResponse;

--- a/src/Client.php
+++ b/src/Client.php
@@ -27,14 +27,14 @@ class Client
      *
      * @var TransportInterface
      */
-    private $transport;
+    protected $transport;
 
     /**
      * Auto close on error.
      *
      * @var bool
      */
-    private $closeOnError = true;
+    protected $closeOnError = true;
 
     /**
      * @param TransportInterface|null $transport
@@ -93,8 +93,6 @@ class Client
      *
      * @param RequestInterface  $request
      * @param ResponseInterface $response
-     * @param array             $vars
-     * @param array             $flags
      *
      * @throws TransportException
      *
@@ -102,9 +100,7 @@ class Client
      */
     public function request(
         RequestInterface $request,
-        ResponseInterface $response,
-        array $vars = [],
-        array $flags = []
+        ResponseInterface $response
     ) {
         $transport = $this->getTransport();
 
@@ -113,8 +109,7 @@ class Client
                 $request->getMethod(),
                 (string) $request->getUri(),
                 $request->getHeaders(),
-                $vars,
-                $flags
+                (string) $request->getBody()
             );
         } catch (TransportException $exception) {
             if ($this->closeOnError) {

--- a/src/Option/OptionFactory.php
+++ b/src/Option/OptionFactory.php
@@ -76,6 +76,8 @@ abstract class OptionFactory
 
         'forbid-reuse'       => CURLOPT_FORBID_REUSE,
         'fresh-connect'      => CURLOPT_FRESH_CONNECT,
+
+        'max-connections'    => CURLOPT_MAXCONNECTS,
     ];
 
     /**
@@ -129,6 +131,8 @@ abstract class OptionFactory
         CURLOPT_PROXYPORT      => ['type' => 'int'],
         // Size of the buffer for each read
         CURLOPT_BUFFERSIZE     => ['type' => 'int'],
+        // The maximum amount of persistent connections
+        CURLOPT_MAXCONNECTS    => ['type' => 'int'],
 
         // String
         // Contents of the "User-Agent: " header to be used in a HTTP request

--- a/src/Transport/AbstractTransport.php
+++ b/src/Transport/AbstractTransport.php
@@ -74,6 +74,8 @@ abstract class AbstractTransport implements TransportInterface
 
     /**
      * {@inheritdoc}
+     * @param integer|string|OptionInterface $option
+     * @param mixed $value
      */
     public function hasOption($option, $value = null)
     {
@@ -98,6 +100,7 @@ abstract class AbstractTransport implements TransportInterface
 
     /**
      * {@inheritdoc}
+     * @param integer|string|OptionInterface $option
      */
     public function removeOption($option)
     {
@@ -113,6 +116,9 @@ abstract class AbstractTransport implements TransportInterface
 
         $this->options = array_filter(
             $this->options,
+            /**
+             * @param OptionInterface $transportOption
+             */
             function ($transportOption) use ($option) {
                 /* @var OptionInterface $transportOption */
                 return !($transportOption->getOption() === $option);
@@ -125,7 +131,7 @@ abstract class AbstractTransport implements TransportInterface
      *
      * @param string $uri
      * @param array  $headers
-     * @param string $requestBody
+     * @param string|null $requestBody
      *
      * @return string
      */
@@ -139,7 +145,7 @@ abstract class AbstractTransport implements TransportInterface
      *
      * @param string $uri
      * @param array  $headers
-     * @param string $requestBody
+     * @param string|null $requestBody
      *
      * @return string
      */
@@ -153,7 +159,7 @@ abstract class AbstractTransport implements TransportInterface
      *
      * @param string $uri
      * @param array  $headers
-     * @param string $requestBody
+     * @param string|null $requestBody
      *
      * @return string
      */
@@ -167,7 +173,7 @@ abstract class AbstractTransport implements TransportInterface
      *
      * @param string $uri
      * @param array  $headers
-     * @param string $requestBody
+     * @param string|null $requestBody
      *
      * @return string
      */
@@ -181,7 +187,7 @@ abstract class AbstractTransport implements TransportInterface
      *
      * @param string $uri
      * @param array  $headers
-     * @param string $requestBody
+     * @param string|null $requestBody
      *
      * @return string
      */
@@ -195,7 +201,7 @@ abstract class AbstractTransport implements TransportInterface
      *
      * @param string $uri
      * @param array  $headers
-     * @param string $requestBody
+     * @param string|null $requestBody
      *
      * @return string
      */
@@ -209,7 +215,7 @@ abstract class AbstractTransport implements TransportInterface
      *
      * @param string $uri
      * @param array  $headers
-     * @param string $requestBody
+     * @param string|null $requestBody
      *
      * @return string
      */

--- a/src/Transport/AbstractTransport.php
+++ b/src/Transport/AbstractTransport.php
@@ -74,6 +74,7 @@ abstract class AbstractTransport implements TransportInterface
 
     /**
      * {@inheritdoc}
+     *
      * @param int|string|OptionInterface $option
      * @param mixed                      $value
      */
@@ -100,6 +101,7 @@ abstract class AbstractTransport implements TransportInterface
 
     /**
      * {@inheritdoc}
+     *
      * @param int|string|OptionInterface $option
      */
     public function removeOption($option)

--- a/src/Transport/AbstractTransport.php
+++ b/src/Transport/AbstractTransport.php
@@ -74,8 +74,8 @@ abstract class AbstractTransport implements TransportInterface
 
     /**
      * {@inheritdoc}
-     * @param integer|string|OptionInterface $option
-     * @param mixed $value
+     * @param int|string|OptionInterface $option
+     * @param mixed                      $value
      */
     public function hasOption($option, $value = null)
     {
@@ -100,7 +100,7 @@ abstract class AbstractTransport implements TransportInterface
 
     /**
      * {@inheritdoc}
-     * @param integer|string|OptionInterface $option
+     * @param int|string|OptionInterface $option
      */
     public function removeOption($option)
     {
@@ -129,8 +129,8 @@ abstract class AbstractTransport implements TransportInterface
     /**
      * Shorthand for OPTIONS cURL request.
      *
-     * @param string $uri
-     * @param array  $headers
+     * @param string      $uri
+     * @param array       $headers
      * @param string|null $requestBody
      *
      * @return string
@@ -143,8 +143,8 @@ abstract class AbstractTransport implements TransportInterface
     /**
      * Shorthand for HEAD cURL request.
      *
-     * @param string $uri
-     * @param array  $headers
+     * @param string      $uri
+     * @param array       $headers
      * @param string|null $requestBody
      *
      * @return string
@@ -157,8 +157,8 @@ abstract class AbstractTransport implements TransportInterface
     /**
      * Shorthand for GET cURL request.
      *
-     * @param string $uri
-     * @param array  $headers
+     * @param string      $uri
+     * @param array       $headers
      * @param string|null $requestBody
      *
      * @return string
@@ -171,8 +171,8 @@ abstract class AbstractTransport implements TransportInterface
     /**
      * Shorthand for POST cURL request.
      *
-     * @param string $uri
-     * @param array  $headers
+     * @param string      $uri
+     * @param array       $headers
      * @param string|null $requestBody
      *
      * @return string
@@ -185,8 +185,8 @@ abstract class AbstractTransport implements TransportInterface
     /**
      * Shorthand for PUT cURL request.
      *
-     * @param string $uri
-     * @param array  $headers
+     * @param string      $uri
+     * @param array       $headers
      * @param string|null $requestBody
      *
      * @return string
@@ -199,8 +199,8 @@ abstract class AbstractTransport implements TransportInterface
     /**
      * Shorthand for DELETE cURL request.
      *
-     * @param string $uri
-     * @param array  $headers
+     * @param string      $uri
+     * @param array       $headers
      * @param string|null $requestBody
      *
      * @return string
@@ -213,8 +213,8 @@ abstract class AbstractTransport implements TransportInterface
     /**
      * Shorthand for PATCH cURL request.
      *
-     * @param string $uri
-     * @param array  $headers
+     * @param string      $uri
+     * @param array       $headers
      * @param string|null $requestBody
      *
      * @return string

--- a/src/Transport/AbstractTransport.php
+++ b/src/Transport/AbstractTransport.php
@@ -125,13 +125,13 @@ abstract class AbstractTransport implements TransportInterface
      *
      * @param string $uri
      * @param array  $headers
-     * @param array  $vars
+     * @param string $requestBody
      *
      * @return string
      */
-    public function options($uri, array $headers = [], array $vars = [])
+    public function options($uri, array $headers = [], $requestBody = null)
     {
-        return $this->request(RequestMethodInterface::METHOD_OPTIONS, $uri, $headers, $vars);
+        return $this->request(RequestMethodInterface::METHOD_OPTIONS, $uri, $headers, $requestBody);
     }
 
     /**
@@ -139,13 +139,13 @@ abstract class AbstractTransport implements TransportInterface
      *
      * @param string $uri
      * @param array  $headers
-     * @param array  $vars
+     * @param string $requestBody
      *
      * @return string
      */
-    public function head($uri, array $headers = [], array $vars = [])
+    public function head($uri, array $headers = [], $requestBody = null)
     {
-        return $this->request(RequestMethodInterface::METHOD_HEAD, $uri, $headers, $vars);
+        return $this->request(RequestMethodInterface::METHOD_HEAD, $uri, $headers, $requestBody);
     }
 
     /**
@@ -153,13 +153,13 @@ abstract class AbstractTransport implements TransportInterface
      *
      * @param string $uri
      * @param array  $headers
-     * @param array  $vars
+     * @param string $requestBody
      *
      * @return string
      */
-    public function get($uri, array $headers = [], array $vars = [])
+    public function get($uri, array $headers = [], $requestBody = null)
     {
-        return $this->request(RequestMethodInterface::METHOD_GET, $uri, $headers, $vars);
+        return $this->request(RequestMethodInterface::METHOD_GET, $uri, $headers, $requestBody);
     }
 
     /**
@@ -167,14 +167,13 @@ abstract class AbstractTransport implements TransportInterface
      *
      * @param string $uri
      * @param array  $headers
-     * @param array  $vars
-     * @param array  $flags
+     * @param string $requestBody
      *
      * @return string
      */
-    public function post($uri, array $headers = [], array $vars = [], array $flags = [])
+    public function post($uri, array $headers = [], $requestBody = null)
     {
-        return $this->request(RequestMethodInterface::METHOD_POST, $uri, $headers, $vars, $flags);
+        return $this->request(RequestMethodInterface::METHOD_POST, $uri, $headers, $requestBody);
     }
 
     /**
@@ -182,13 +181,13 @@ abstract class AbstractTransport implements TransportInterface
      *
      * @param string $uri
      * @param array  $headers
-     * @param array  $vars
+     * @param string $requestBody
      *
      * @return string
      */
-    public function put($uri, array $headers = [], array $vars = [])
+    public function put($uri, array $headers = [], $requestBody = null)
     {
-        return $this->request(RequestMethodInterface::METHOD_PUT, $uri, $headers, $vars);
+        return $this->request(RequestMethodInterface::METHOD_PUT, $uri, $headers, $requestBody);
     }
 
     /**
@@ -196,13 +195,13 @@ abstract class AbstractTransport implements TransportInterface
      *
      * @param string $uri
      * @param array  $headers
-     * @param array  $vars
+     * @param string $requestBody
      *
      * @return string
      */
-    public function delete($uri, array $headers = [], array $vars = [])
+    public function delete($uri, array $headers = [], $requestBody = null)
     {
-        return $this->request(RequestMethodInterface::METHOD_DELETE, $uri, $headers, $vars);
+        return $this->request(RequestMethodInterface::METHOD_DELETE, $uri, $headers, $requestBody);
     }
 
     /**
@@ -210,12 +209,12 @@ abstract class AbstractTransport implements TransportInterface
      *
      * @param string $uri
      * @param array  $headers
-     * @param array  $vars
+     * @param string $requestBody
      *
      * @return string
      */
-    public function patch($uri, array $headers = [], array $vars = [])
+    public function patch($uri, array $headers = [], $requestBody = null)
     {
-        return $this->request(RequestMethodInterface::METHOD_PATCH, $uri, $headers, $vars);
+        return $this->request(RequestMethodInterface::METHOD_PATCH, $uri, $headers, $requestBody);
     }
 }

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -117,7 +117,7 @@ class Curl extends AbstractTransport
      *
      * @throws TransportException
      */
-    public function request($method, $uri, array $headers = [], array $vars = [], array $flags = [])
+    public function request($method, $uri, array $headers = [], $requestBody = null)
     {
         $this->close();
         $this->handler = curl_init();
@@ -128,31 +128,8 @@ class Curl extends AbstractTransport
         $this->forgeOptions($this->options);
         $this->forgeHeaders($headers);
 
-        $flags = array_merge(['post_multipart' => false], $flags);
-
-        if (count($vars)) {
-            $parameters = $vars;
-
-            if (in_array(
-                $method,
-                [
-                    RequestMethodInterface::METHOD_OPTIONS,
-                    RequestMethodInterface::METHOD_HEAD,
-                    RequestMethodInterface::METHOD_GET,
-                    RequestMethodInterface::METHOD_PUT,
-                    RequestMethodInterface::METHOD_DELETE,
-                ],
-                true
-            )) {
-                $parameters = null;
-                $uri .= ((strpos($uri, '?') !== false) ? '&' : '?') . http_build_query($vars, '', '&');
-            } elseif ($method !== RequestMethodInterface::METHOD_POST || $flags['post_multipart'] !== true) {
-                $parameters = http_build_query($vars, '', '&');
-            }
-
-            if ($parameters !== null) {
-                curl_setopt($this->handler, CURLOPT_POSTFIELDS, $parameters);
-            }
+        if ($requestBody !== null && $requestBody) {
+            curl_setopt($this->handler, CURLOPT_POSTFIELDS, $requestBody);
         }
         curl_setopt($this->handler, CURLOPT_URL, $uri);
 

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -119,7 +119,6 @@ class Curl extends AbstractTransport
      */
     public function request($method, $uri, array $headers = [], $requestBody = null)
     {
-        $this->close();
         $this->handler = curl_init();
 
         $method = strtoupper($method);

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -151,7 +151,7 @@ class Curl extends AbstractTransport
     }
 
     /**
-     * Create or reuse existing handle
+     * Create or reuse existing handle.
      *
      * @return resource
      */

--- a/src/Transport/Curl.php
+++ b/src/Transport/Curl.php
@@ -171,6 +171,7 @@ class Curl extends AbstractTransport
         } else {
             $this->handler = curl_init();
         }
+
         return $this->handler;
     }
 

--- a/src/Transport/TransportInterface.php
+++ b/src/Transport/TransportInterface.php
@@ -21,7 +21,7 @@ interface TransportInterface
      * @param string $method
      * @param string $uri
      * @param array  $headers
-     * @param string $requestBody
+     * @param string|null $requestBody
      *
      * @return string
      */

--- a/src/Transport/TransportInterface.php
+++ b/src/Transport/TransportInterface.php
@@ -21,12 +21,11 @@ interface TransportInterface
      * @param string $method
      * @param string $uri
      * @param array  $headers
-     * @param array  $vars
-     * @param array  $flags
+     * @param string $requestBody
      *
      * @return string
      */
-    public function request($method, $uri, array $headers = [], array $vars = [], array $flags = []);
+    public function request($method, $uri, array $headers = [], $requestBody = null);
 
     /**
      * Retrieve response information.

--- a/src/Transport/TransportInterface.php
+++ b/src/Transport/TransportInterface.php
@@ -18,9 +18,9 @@ interface TransportInterface
     /**
      * Perform a cURL request.
      *
-     * @param string $method
-     * @param string $uri
-     * @param array  $headers
+     * @param string      $method
+     * @param string      $uri
+     * @param array       $headers
      * @param string|null $requestBody
      *
      * @return string

--- a/tests/Spiral/ClientTest.php
+++ b/tests/Spiral/ClientTest.php
@@ -103,9 +103,6 @@ RESP;
             ->expects(static::once())
             ->method('responseInfo')
             ->will(static::returnValue($transferInfo));
-        $transport
-            ->expects(static::once())
-            ->method('close');
 
         $request = new Request('', 'GET');
         $response = new Response;

--- a/tests/Spiral/Transport/CurlTest.php
+++ b/tests/Spiral/Transport/CurlTest.php
@@ -19,6 +19,9 @@ use Jgut\Spiral\Transport\Curl;
  */
 class CurlTest extends \PHPUnit_Framework_TestCase
 {
+
+    const TESTHOST = 'http://httpbin.org';
+
     /**
      * @expectedException \Jgut\Spiral\Exception\OptionException
      */
@@ -73,7 +76,7 @@ class CurlTest extends \PHPUnit_Framework_TestCase
 
         static::assertNull($transport->responseInfo());
 
-        $transport->request(RequestMethodInterface::METHOD_GET, 'http://www.php.net', ['Accept-Charset' => 'utf-8']);
+        $transport->request(RequestMethodInterface::METHOD_GET, static::TESTHOST, ['Accept-Charset' => 'utf-8']);
 
         static::assertInternalType('array', $transport->responseInfo());
         static::assertEquals(200, $transport->responseInfo(CURLINFO_HTTP_CODE));
@@ -88,14 +91,14 @@ class CurlTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider methodProvider
      */
-    public function testRequestMethods($method, $shorthand, $expectedCode)
+    public function testRequestMethods($method, $shorthand, $expectedCode, $path)
     {
         $transport = Curl::createFromDefaults();
 
-        $transport->request($method, 'http://www.php.net');
+        $transport->request($method, static::TESTHOST . $path);
         static::assertEquals($expectedCode, $transport->responseInfo(CURLINFO_HTTP_CODE));
 
-        $transport->{$shorthand}('http://www.php.net');
+        $transport->{$shorthand}(static::TESTHOST . $path);
         static::assertEquals($expectedCode, $transport->responseInfo(CURLINFO_HTTP_CODE));
 
         $transport->close();
@@ -109,10 +112,10 @@ class CurlTest extends \PHPUnit_Framework_TestCase
     public function methodProvider()
     {
         return [
-            [RequestMethodInterface::METHOD_OPTIONS, 'options', 200],
-            [RequestMethodInterface::METHOD_HEAD, 'head', 200],
-            [RequestMethodInterface::METHOD_GET, 'get', 200],
-            [RequestMethodInterface::METHOD_DELETE, 'delete', 200],
+            [RequestMethodInterface::METHOD_OPTIONS, 'options', 200, '/'],
+            [RequestMethodInterface::METHOD_HEAD, 'head', 200, '/'],
+            [RequestMethodInterface::METHOD_GET, 'get', 200, '/'],
+            [RequestMethodInterface::METHOD_DELETE, 'delete', 200, '/delete'],
         ];
     }
 
@@ -123,14 +126,14 @@ class CurlTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider methodPayloadProvider
      */
-    public function testRequestWithPayload($method, $shorthand, $expectedCode)
+    public function testRequestWithPayload($method, $shorthand, $expectedCode, $path)
     {
         $transport = Curl::createFromDefaults();
 
-        $transport->request($method, 'http://www.php.net', [], ['var' => 'value']);
+        $transport->request($method, static::TESTHOST . $path, [], 'var=value');
         static::assertEquals($expectedCode, $transport->responseInfo(CURLINFO_HTTP_CODE));
 
-        $transport->{$shorthand}('http://www.php.net', [], ['var' => 'value']);
+        $transport->{$shorthand}(static::TESTHOST . $path, [], 'var=value');
         static::assertEquals($expectedCode, $transport->responseInfo(CURLINFO_HTTP_CODE));
 
         $transport->close();
@@ -144,9 +147,9 @@ class CurlTest extends \PHPUnit_Framework_TestCase
     public function methodPayloadProvider()
     {
         return [
-            [RequestMethodInterface::METHOD_POST, 'post', 200],
-            [RequestMethodInterface::METHOD_PUT, 'put', 200],
-            [RequestMethodInterface::METHOD_PATCH, 'patch', 200],
+            [RequestMethodInterface::METHOD_POST, 'post', 200, '/post'],
+            [RequestMethodInterface::METHOD_PUT, 'put', 200, '/put'],
+            [RequestMethodInterface::METHOD_PATCH, 'patch', 200, '/patch'],
         ];
     }
 }

--- a/tests/Spiral/Transport/CurlTest.php
+++ b/tests/Spiral/Transport/CurlTest.php
@@ -19,7 +19,6 @@ use Jgut\Spiral\Transport\Curl;
  */
 class CurlTest extends \PHPUnit_Framework_TestCase
 {
-
     const TESTHOST = 'http://httpbin.org';
 
     /**


### PR DESCRIPTION
This PR addresses the issues #8 and #10 

I've changed the behavior of the requests to use the PSR7-Request body instead of the `$vars` parameter. For unit testing, I had to change the URLs, cause php.net did respond with 405 codes (at least in my network).

For HTTP-Keep-Alive, I removed two additional `close()` calls. The implementation in my existing application using PSR7 does work now. I could even measure a performance increase on around 10-20ms per request in comparison to the former used lib.